### PR TITLE
Add input parameter for AMI

### DIFF
--- a/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
@@ -22,39 +22,39 @@ Description: >
   WSO2 Identity Server single node deployment with puppet master agent setup
 
 ##############################################################################################
-# Mappings for Ubuntu AMIs
+# Mappings for centOS AMIs
 # Refer https://cloud-images.ubuntu.com/locator/ec2/ for ubuntu AMI-ID's for the LTS version
 ##############################################################################################
 Mappings:
   RegionMap:
     ap-northeast-1:
-      AMI: ami-2f2d9c49
+      AMI: ami-25bd2743
     ap-northeast-2:
-      AMI: ami-e49e398a
+      AMI: ami-7248e81c
     ap-south-1:
-      AMI: ami-46eea129
+      AMI: ami-5d99ce32
     ap-southeast-1:
-      AMI: ami-84a6f3e7
+      AMI: ami-d2fa88ae
     ap-southeast-2:
-      AMI: ami-4cc8232e
+      AMI: ami-b6bb47d4
     ca-central-1:
-      AMI: ami-338b3057
+      AMI: ami-dcad28b8
     eu-central-1:
-      AMI: ami-e22aaa8d
+      AMI: ami-337be65c
     eu-west-1:
-      AMI: ami-2e832957
+      AMI: ami-6e28b517
     eu-west-2:
-      AMI: ami-3fc8d75b
+      AMI: ami-ee6a718a
     sa-east-1:
-      AMI: ami-981550f4
+      AMI: ami-f9adef95
     us-east-1:
-      AMI: ami-c29e1cb8
+      AMI: ami-4bf3d731
     us-east-2:
-      AMI: ami-f0f8d695
+      AMI: ami-e1496384
     us-west-1:
-      AMI: ami-8b90a9eb
+      AMI: ami-65e0e305
     us-west-2:
-      AMI: ami-25cf1c5d
+      AMI: ami-a042f4d8
 
 #############################
 # User inputs
@@ -62,15 +62,15 @@ Mappings:
 Parameters:
   AMI:
     Type: String
-    Default: USE_DEFAULT
-    Description: AMI of the region. Keep USE_DEFAULT to use Ubuntu AMI.
+    Default: UBUNTU
+    Description: AMI for us-east-1 region
   JDK:
     Type: String
     Default: "ORACLE_JDK8"
     Description: Target Java version
     AllowedValues:
-      - ORACLE_JDK7
       - ORACLE_JDK8
+      - ORACLE_JDK7
   DBEngine:
     Type: String
     Default: "mysql"
@@ -147,9 +147,8 @@ Parameters:
       - m4.large
     ConstraintDescription: must be a valid EC2 instance type
 
-# Conditions
 Conditions:
-  UseDefaultUbuntuAMI: !Equals [!Ref AMI, USE_DEFAULT]
+  UseDefaultUbuntuAMI: !Equals [!Ref AMI, UBUNTU]
 
 ################################
 # Create AWS resources
@@ -388,8 +387,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: 
-       Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+      ImageId:
+       Fn::If: [UseDefaultUbuntuAMI,!FindInMap [RegionMap, !Ref "AWS::Region", AMI],!Ref AMI]
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -410,7 +409,7 @@ Resources:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
         ImageId:
-          Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+           Fn::If: [UseDefaultUbuntuAMI,!FindInMap [RegionMap, !Ref "AWS::Region", AMI],!Ref AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -456,7 +455,7 @@ Resources:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
       ImageId:
-        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+       Fn::If: [UseDefaultUbuntuAMI,!FindInMap [RegionMap, !Ref "AWS::Region", AMI],!Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -498,7 +497,7 @@ Resources:
       DBInstanceClass: !Ref DBClass
       Engine: !Ref DBEngine
       EngineVersion: !Ref DBEngineVersion
-      DBInstanceIdentifier: wso2-is-dbinstance
+      DBInstanceIdentifier: wso2-is-dbinstance-centos2
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       AutoMinorVersionUpgrade: false
@@ -525,7 +524,7 @@ Resources:
   WSO2EnvISApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: identity-demo
+      Name: identity-demo-centos
       Scheme: internet-facing
       Subnets:
         - !Ref WSO2EnvPublicSubnet1
@@ -543,7 +542,7 @@ Resources:
       HealthCheckPort: 9443
       Matcher:
         HttpCode: 200
-      Name: is-carbon-9443
+      Name: is-3-carbon-9443
       Port: 443
       Protocol: HTTPS
       TargetGroupAttributes:
@@ -559,7 +558,7 @@ Resources:
         Ref: WSO2EnvVPC
       Tags:
       - Key: Name
-        Value: is-carbon-9443
+        Value: is-3-carbon-9443
   WSO2EnvISALBListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -601,4 +600,3 @@ Outputs:
   WSO2ISMCURL:
     Value: !Sub 'https://${WSO2EnvISApplicationLoadBalancer.DNSName}/carbon'
     Description: Access URL of the Management Console
-

--- a/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
@@ -388,8 +388,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId:
-	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+      ImageId: 
+       Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -410,7 +410,7 @@ Resources:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
         ImageId:
-         Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+          Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -456,7 +456,7 @@ Resources:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
       ImageId:
-       Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'

--- a/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
@@ -22,39 +22,39 @@ Description: >
   WSO2 Identity Server single node deployment with puppet master agent setup
 
 ##############################################################################################
-# Mappings for centOS AMIs
+# Mappings for Ubuntu AMIs
 # Refer https://cloud-images.ubuntu.com/locator/ec2/ for ubuntu AMI-ID's for the LTS version
 ##############################################################################################
 Mappings:
   RegionMap:
     ap-northeast-1:
-      AMI: ami-25bd2743
+      AMI: ami-2f2d9c49
     ap-northeast-2:
-      AMI: ami-7248e81c
+      AMI: ami-e49e398a
     ap-south-1:
-      AMI: ami-5d99ce32
+      AMI: ami-46eea129
     ap-southeast-1:
-      AMI: ami-d2fa88ae
+      AMI: ami-84a6f3e7
     ap-southeast-2:
-      AMI: ami-b6bb47d4
+      AMI: ami-4cc8232e
     ca-central-1:
-      AMI: ami-dcad28b8
+      AMI: ami-338b3057
     eu-central-1:
-      AMI: ami-337be65c
+      AMI: ami-e22aaa8d
     eu-west-1:
-      AMI: ami-6e28b517
+      AMI: ami-2e832957
     eu-west-2:
-      AMI: ami-ee6a718a
+      AMI: ami-3fc8d75b
     sa-east-1:
-      AMI: ami-f9adef95
+      AMI: ami-981550f4
     us-east-1:
-      AMI: ami-4bf3d731
+      AMI: ami-c29e1cb8
     us-east-2:
-      AMI: ami-e1496384
+      AMI: ami-f0f8d695
     us-west-1:
-      AMI: ami-65e0e305
+      AMI: ami-8b90a9eb
     us-west-2:
-      AMI: ami-a042f4d8
+      AMI: ami-25cf1c5d
 
 #############################
 # User inputs
@@ -62,15 +62,15 @@ Mappings:
 Parameters:
   AMI:
     Type: String
-    Default: UBUNTU
-    Description: AMI for us-east-1 region
+    Default: READ_FROM_REGIONMAP
+    Description: AMI of the region. Keep READ_FROM_REGIONMAP to map Ubuntu AMI from the RegionMap in the script.
   JDK:
     Type: String
     Default: "ORACLE_JDK8"
     Description: Target Java version
     AllowedValues:
-      - ORACLE_JDK8
       - ORACLE_JDK7
+      - ORACLE_JDK8
   DBEngine:
     Type: String
     Default: "mysql"
@@ -147,8 +147,9 @@ Parameters:
       - m4.large
     ConstraintDescription: must be a valid EC2 instance type
 
+# Conditions
 Conditions:
-  UseDefaultUbuntuAMI: !Equals [!Ref AMI, UBUNTU]
+  UseDefaultUbuntuAMI: !Equals [!Ref AMI, READ_FROM_REGIONMAP]
 
 ################################
 # Create AWS resources
@@ -388,7 +389,7 @@ Resources:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
       ImageId:
-       Fn::If: [UseDefaultUbuntuAMI,!FindInMap [RegionMap, !Ref "AWS::Region", AMI],!Ref AMI]
+       Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -409,7 +410,7 @@ Resources:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
         ImageId:
-           Fn::If: [UseDefaultUbuntuAMI,!FindInMap [RegionMap, !Ref "AWS::Region", AMI],!Ref AMI]
+          Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -455,7 +456,7 @@ Resources:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
       ImageId:
-       Fn::If: [UseDefaultUbuntuAMI,!FindInMap [RegionMap, !Ref "AWS::Region", AMI],!Ref AMI]
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -497,7 +498,7 @@ Resources:
       DBInstanceClass: !Ref DBClass
       Engine: !Ref DBEngine
       EngineVersion: !Ref DBEngineVersion
-      DBInstanceIdentifier: wso2-is-dbinstance-centos2
+      DBInstanceIdentifier: wso2-is-dbinstance
       MasterUsername: !Ref DBUsername
       MasterUserPassword: !Ref DBPassword
       AutoMinorVersionUpgrade: false
@@ -524,7 +525,7 @@ Resources:
   WSO2EnvISApplicationLoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: identity-demo-centos
+      Name: identity-demo
       Scheme: internet-facing
       Subnets:
         - !Ref WSO2EnvPublicSubnet1
@@ -542,7 +543,7 @@ Resources:
       HealthCheckPort: 9443
       Matcher:
         HttpCode: 200
-      Name: is-3-carbon-9443
+      Name: is-carbon-9443
       Port: 443
       Protocol: HTTPS
       TargetGroupAttributes:
@@ -558,7 +559,7 @@ Resources:
         Ref: WSO2EnvVPC
       Tags:
       - Key: Name
-        Value: is-3-carbon-9443
+        Value: is-carbon-9443
   WSO2EnvISALBListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -573,13 +574,13 @@ Resources:
       SslPolicy: ELBSecurityPolicy-TLS-1-1-2017-01
 
 #####################################
-# Print details of the created stack 
+# Print details of the created stack
 #####################################
 Outputs:
-  DatabaseHost: 
+  DatabaseHost:
     Value: !Sub '${WSO2EnvDBInstance.Endpoint.Address}'
     Description: "Database Host"
-  DatabasePort: 
+  DatabasePort:
     Value: !Sub '${WSO2EnvDBInstance.Endpoint.Port}'
     Description: "Database Port"
   BastionEIP:
@@ -600,3 +601,4 @@ Outputs:
   WSO2ISMCURL:
     Value: !Sub 'https://${WSO2EnvISApplicationLoadBalancer.DNSName}/carbon'
     Description: Access URL of the Management Console
+

--- a/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-1/pattern-1-with-puppet-cloudformation.template.yml
@@ -60,6 +60,10 @@ Mappings:
 # User inputs
 #############################
 Parameters:
+  AMI:
+    Type: String
+    Default: USE_DEFAULT
+    Description: AMI of the region. Keep USE_DEFAULT to use Ubuntu AMI.
   JDK:
     Type: String
     Default: "ORACLE_JDK8"
@@ -142,6 +146,10 @@ Parameters:
       - m3.2xlarge
       - m4.large
     ConstraintDescription: must be a valid EC2 instance type
+
+# Conditions
+Conditions:
+  UseDefaultUbuntuAMI: !Equals [!Ref AMI, USE_DEFAULT]
 
 ################################
 # Create AWS resources
@@ -380,7 +388,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -400,7 +409,8 @@ Resources:
       Properties:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
-        ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+        ImageId:
+         Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -445,7 +455,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+       Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'

--- a/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
@@ -401,7 +401,7 @@ Resources:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
       ImageId:
-	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]		
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -422,7 +422,7 @@ Resources:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
         ImageId:
-	 Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+          Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -468,7 +468,7 @@ Resources:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
       ImageId:
-	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -508,7 +508,7 @@ Resources:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
       ImageId:
-	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'

--- a/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
@@ -60,13 +60,17 @@ Mappings:
 # User inputs
 #############################
 Parameters:
+  AMI:
+    Type: String
+    Default: READ_FROM_REGIONMAP
+    Description: AMI of the region. Keep READ_FROM_REGIONMAP to map Ubuntu AMI from the RegionMap in the script.
   JDK:
     Type: String
-    Default: "JDK8"
+    Default: "ORACLE_JDK8"
     Description: Target Java version
     AllowedValues:
-      - JDK7
-      - JDK8
+      - ORACLE_JDK7
+      - ORACLE_JDK8
   DBEngine:
     Type: String
     Default: "mysql"
@@ -150,6 +154,11 @@ Parameters:
     Type: String
     NoEcho: true
     Description: The AWS Access Key Secret used for internal AWS clustering
+
+# Conditions
+Conditions:
+  UseDefaultUbuntuAMI: !Equals [!Ref AMI, READ_FROM_REGIONMAP]
+
 ################################
 # Create AWS resources
 ################################
@@ -391,7 +400,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -411,7 +421,8 @@ Resources:
       Properties:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
-        ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+        ImageId:
+          Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -456,7 +467,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -495,7 +507,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'

--- a/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
@@ -60,17 +60,13 @@ Mappings:
 # User inputs
 #############################
 Parameters:
-  AMI:
-    Type: String
-    Default: USE_DEFAULT
-    Description: AMI of the region. Keep USE_DEFAULT to use Ubuntu AMI.
   JDK:
     Type: String
-    Default: "ORACLE_JDK8"
+    Default: "JDK8"
     Description: Target Java version
     AllowedValues:
-      - ORACLE_JDK7
-      - ORACLE_JDK8
+      - JDK7
+      - JDK8
   DBEngine:
     Type: String
     Default: "mysql"
@@ -154,11 +150,6 @@ Parameters:
     Type: String
     NoEcho: true
     Description: The AWS Access Key Secret used for internal AWS clustering
-
-# Conditions
-Conditions:
-  UseDefaultUbuntuAMI: !Equals [!Ref AMI, USE_DEFAULT]
-
 ################################
 # Create AWS resources
 ################################
@@ -400,8 +391,7 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId:
-        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -421,8 +411,7 @@ Resources:
       Properties:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
-        ImageId:
-          Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+        ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -467,8 +456,7 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId:
-        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -507,8 +495,7 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId:
-        Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
+      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'

--- a/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
+++ b/cloudformation-templates/pattern-2/pattern-2-with-puppet-cloudformation.template.yml
@@ -60,6 +60,10 @@ Mappings:
 # User inputs
 #############################
 Parameters:
+  AMI:
+    Type: String
+    Default: USE_DEFAULT
+    Description: AMI of the region. Keep USE_DEFAULT to use Ubuntu AMI.
   JDK:
     Type: String
     Default: "ORACLE_JDK8"
@@ -150,6 +154,11 @@ Parameters:
     Type: String
     NoEcho: true
     Description: The AWS Access Key Secret used for internal AWS clustering
+
+# Conditions
+Conditions:
+  UseDefaultUbuntuAMI: !Equals [!Ref AMI, USE_DEFAULT]
+
 ################################
 # Create AWS resources
 ################################
@@ -391,7 +400,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]		
       InstanceType: t2.micro
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -411,7 +421,8 @@ Resources:
       Properties:
         DisableApiTermination: 'false'
         InstanceInitiatedShutdownBehavior: stop
-        ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+        ImageId:
+	 Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
         InstanceType: t2.micro
         KeyName: !Ref EC2KeyPair
         Monitoring: 'false'
@@ -456,7 +467,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'
@@ -495,7 +507,8 @@ Resources:
     Properties:
       DisableApiTermination: 'false'
       InstanceInitiatedShutdownBehavior: stop
-      ImageId: !FindInMap [RegionMap, !Ref "AWS::Region", AMI]
+      ImageId:
+	Fn::If: [UseDefaultUbuntuAMI, !FindInMap [RegionMap, !Ref "AWS::Region", AMI], !Ref AMI]
       InstanceType: !Ref WSO2ISInstanceType
       KeyName: !Ref EC2KeyPair
       Monitoring: 'false'


### PR DESCRIPTION
## Purpose
> The previous script was mapping Ubuntu AMI from a map in the script. But a requirement occurred as needing to run the script in a different OS (different specific AMI). 

## Approach
> Added a new parameter to get AMI. If there is no specific AMI, keeping "USE_DEFAULT" will use the relevant Ubuntu AMI from the map in the script.